### PR TITLE
Could com.yuzhouwan:yuzhouwan-site-api:1.1.0 drop off redundant dependencies to loose weight?

### DIFF
--- a/yuzhouwan-site/yuzhouwan-site-api/pom.xml
+++ b/yuzhouwan-site/yuzhouwan-site-api/pom.xml
@@ -17,6 +17,16 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>${hibernate.validator.version}</version>
+            <exclusions>
+               <exclusion>
+                  <groupId>com.fasterxml</groupId>
+                  <artifactId>classmate</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>org.jboss.logging</groupId>
+                  <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -27,11 +37,35 @@
             <groupId>com.mangofactory</groupId>
             <artifactId>swagger-springmvc</artifactId>
             <version>${swagger.spring.mvc.version}</version>
+            <exclusions>
+               <exclusion>
+                  <groupId>com.mangofactory</groupId>
+                  <artifactId>swagger-models</artifactId>
+               </exclusion>
+               <exclusion>
+                   <groupId>joda-time</groupId>
+                   <artifactId>joda-time</artifactId>
+               </exclusion>
+               <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml</groupId>
+                    <artifactId>classmate</artifactId>
+                 </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Hi, I am a user of project **_com.yuzhouwan:yuzhouwan-site-api:1.1.0_**. I found that its pom file introduced **_22_** dependencies. However, among them, **_6_** libraries (**_27%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for this project. 
This PR helps **_com.yuzhouwan:yuzhouwan-site-api:1.1.0_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.


Best regards