### PR TITLE
Upgrade snmp4j, fabric8, hibernate-validator and disruptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <javaee.version>8.0.1</javaee.version>
         <jstl.version>1.2</jstl.version>
         <file.upload.version>1.6.0</file.upload.version>
-        <hibernate.validator.version>5.2.4.Final</hibernate.validator.version>
+        <hibernate.validator.version>8.0.4.Final</hibernate.validator.version>
         <spring.test.version>4.2.2.RELEASE</spring.test.version>
 
         <!-- mybatis -->
@@ -129,7 +129,7 @@
         <cglib.version>3.3.0</cglib.version>
 
         <!-- snmp4j -->
-        <snmp4j.version>3.8.0</snmp4j.version>
+        <snmp4j.version>3.12.2</snmp4j.version>
         <snmp4j.agent.version>3.9.1</snmp4j.agent.version>
 
         <!-- log -->
@@ -152,7 +152,7 @@
         <itextpdf.version>5.5.13.5</itextpdf.version>
 
         <!-- lmax disruptor -->
-        <lmax.disruptor.version>3.4.4</lmax.disruptor.version>
+        <lmax.disruptor.version>4.0.0</lmax.disruptor.version>
 
         <!-- json -->
         <fastjson.version>1.2.83</fastjson.version>
@@ -247,7 +247,7 @@
         <iotdb.version>0.12.5</iotdb.version>
 
         <!-- kubernetes -->
-        <fabric8.version>7.0.1</fabric8.version>
+        <fabric8.version>7.8.0</fabric8.version>
 
         <!-- docker -->
         <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <jstl.version>1.2</jstl.version>
         <file.upload.version>1.6.0</file.upload.version>
         <hibernate.validator.version>8.0.4.Final</hibernate.validator.version>
+        <jakarta.validation.api.version>3.0.2</jakarta.validation.api.version>
         <spring.test.version>4.2.2.RELEASE</spring.test.version>
 
         <!-- mybatis -->

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/KafkaUtils.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/KafkaUtils.java
@@ -4,6 +4,7 @@ import com.lmax.disruptor.BlockingWaitStrategy;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 import com.yuzhouwan.bigdata.kafka.util.pc.AvroEvent;
 import com.yuzhouwan.bigdata.kafka.util.pc.AvroEventFactory;
 import com.yuzhouwan.bigdata.kafka.util.pc.AvroEventProducer;
@@ -23,7 +24,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.Executors;
 
 import static com.yuzhouwan.bigdata.kafka.util.KafkaConnPoolUtils.getPool;
 import static com.yuzhouwan.common.util.ExceptionUtils.errorInfo;
@@ -72,7 +72,7 @@ public final class KafkaUtils {
     private static void disruptor() {
         AvroEventFactory factory = new AvroEventFactory();
         Disruptor<AvroEvent> disruptor = new Disruptor<>(factory, RING_BUFFER_SIZE,
-                Executors.newCachedThreadPool(),
+                DaemonThreadFactory.INSTANCE,
                 ProducerType.MULTI,
                 new BlockingWaitStrategy());
         Collection<Producer<String, byte[]>> pool = getPool();
@@ -83,7 +83,7 @@ public final class KafkaUtils {
             avroEventWorkHandlers[count] = new AvroEventWorkHandler(producer, KAFKA_TOPIC, count);
             count++;
         }
-        disruptor.handleEventsWithWorkerPool(avroEventWorkHandlers);
+        disruptor.handleEventsWith(avroEventWorkHandlers);
         disruptor.start();
 
         RingBuffer<AvroEvent> ringBuffer = disruptor.getRingBuffer();

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/pc/AvroEventWorkHandler.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/pc/AvroEventWorkHandler.java
@@ -1,6 +1,6 @@
 package com.yuzhouwan.bigdata.kafka.util.pc;
 
-import com.lmax.disruptor.WorkHandler;
+import com.lmax.disruptor.EventHandler;
 import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;
 
@@ -12,7 +12,7 @@ import kafka.producer.KeyedMessage;
  * @author Benedict Jin
  * @since 2017/3/17
  */
-public class AvroEventWorkHandler implements WorkHandler<AvroEvent> {
+public class AvroEventWorkHandler implements EventHandler<AvroEvent> {
 
     private final Producer<String, byte[]> producer;
     private final String topic;
@@ -25,7 +25,7 @@ public class AvroEventWorkHandler implements WorkHandler<AvroEvent> {
     }
 
     @Override
-    public void onEvent(AvroEvent event) {
+    public void onEvent(AvroEvent event, long sequence, boolean endOfBatch) {
         producer.send(new KeyedMessage<>(topic, partition, event.getValue()));
     }
 }

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/test/java/com/yuzhouwan/bigdata/kafka/util/KafkaUtilsTest.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/test/java/com/yuzhouwan/bigdata/kafka/util/KafkaUtilsTest.java
@@ -4,6 +4,7 @@ import com.lmax.disruptor.BlockingWaitStrategy;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 import com.yuzhouwan.bigdata.kafka.util.pc.AvroEvent;
 import com.yuzhouwan.bigdata.kafka.util.pc.AvroEventFactory;
 import com.yuzhouwan.bigdata.kafka.util.pc.AvroEventProducer;
@@ -12,8 +13,6 @@ import com.yuzhouwan.common.util.DecimalUtils;
 import kafka.javaapi.producer.Producer;
 
 import java.nio.ByteBuffer;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
 /**
  * Copyright @ 2024 yuzhouwan.com
@@ -29,12 +28,11 @@ public class KafkaUtilsTest {
 
     public static void main(String[] args) {
 
-        Executor executor = Executors.newCachedThreadPool();
         AvroEventFactory factory = new AvroEventFactory();
-        Disruptor<AvroEvent> disruptor = new Disruptor<>(factory, BUFFER_SIZE, executor,
+        Disruptor<AvroEvent> disruptor = new Disruptor<>(factory, BUFFER_SIZE, DaemonThreadFactory.INSTANCE,
                 ProducerType.MULTI, new BlockingWaitStrategy());
         Producer<String, byte[]> kafkaConn = KafkaConnPoolUtils.getPool().iterator().next();
-        disruptor.handleEventsWithWorkerPool(new AvroEventWorkHandler(kafkaConn, "topic", 1)/*,...*/);
+        disruptor.handleEventsWith(new AvroEventWorkHandler(kafkaConn, "topic", 1)/*,...*/);
         disruptor.start();
 
         RingBuffer<AvroEvent> ringBuffer = disruptor.getRingBuffer();

--- a/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/concurrent/producer/consumer/LongEventMain.java
+++ b/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/concurrent/producer/consumer/LongEventMain.java
@@ -4,10 +4,9 @@ import com.lmax.disruptor.BlockingWaitStrategy;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 
 import java.nio.ByteBuffer;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
 /**
  * Copyright @ 2024 yuzhouwan.com
@@ -20,15 +19,14 @@ import java.util.concurrent.Executors;
 public class LongEventMain {
 
     public static void main(String[] args) {
-        Executor executor = Executors.newCachedThreadPool();
         LongEventFactory factory = new LongEventFactory();
         int bufferSize = 1024 * 1024 * 16;
         Disruptor<LongEvent> disruptor = new Disruptor<>(factory,
-                bufferSize, executor,
+                bufferSize, DaemonThreadFactory.INSTANCE,
                 ProducerType.MULTI,
                 new BlockingWaitStrategy());
         disruptor.handleEventsWith(new LongEventHandler());
-        disruptor.handleEventsWithWorkerPool(new LongEventWorkHandler("worker-1"),
+        disruptor.handleEventsWith(new LongEventWorkHandler("worker-1"),
                 new LongEventWorkHandler("worker-2"),
                 new LongEventWorkHandler("worker-3"));
 

--- a/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/concurrent/producer/consumer/LongEventWorkHandler.java
+++ b/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/concurrent/producer/consumer/LongEventWorkHandler.java
@@ -1,6 +1,6 @@
 package com.yuzhouwan.hacker.concurrent.producer.consumer;
 
-import com.lmax.disruptor.WorkHandler;
+import com.lmax.disruptor.EventHandler;
 
 /**
  * Copyright @ 2024 yuzhouwan.com
@@ -10,7 +10,7 @@ import com.lmax.disruptor.WorkHandler;
  * @author Benedict Jin
  * @since 2017/3/16
  */
-public class LongEventWorkHandler implements WorkHandler<LongEvent> {
+public class LongEventWorkHandler implements EventHandler<LongEvent> {
 
     private final String workerName;
 
@@ -19,7 +19,7 @@ public class LongEventWorkHandler implements WorkHandler<LongEvent> {
     }
 
     @Override
-    public void onEvent(LongEvent event) {
+    public void onEvent(LongEvent event, long sequence, boolean endOfBatch) {
 //        System.out.println(workerName + " handle event:" + event);
     }
 }

--- a/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/snmp/acl/SnmpUtil.java
+++ b/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/snmp/acl/SnmpUtil.java
@@ -4,7 +4,6 @@ import org.apache.log4j.BasicConfigurator;
 import org.snmp4j.*;
 import org.snmp4j.asn1.BER;
 import org.snmp4j.event.ResponseEvent;
-import org.snmp4j.log.LogFactory;
 import org.snmp4j.mp.*;
 import org.snmp4j.security.*;
 import org.snmp4j.smi.*;
@@ -257,7 +256,6 @@ public class SnmpUtil extends Thread implements PDUFactory, CommandResponder {
             checkTrapVariables(vbs);
         }
         address = new UdpAddress(host + "/" + _port);
-        LogFactory.setLogFactory(new LogFactory());
         BER.setCheckSequenceLength(false);
     }
 

--- a/yuzhouwan-hacker/src/test/java/com/yuzhouwan/hacker/kubernetes/PodTest.java
+++ b/yuzhouwan-hacker/src/test/java/com/yuzhouwan/hacker/kubernetes/PodTest.java
@@ -3,10 +3,10 @@ package com.yuzhouwan.hacker.kubernetes;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
-import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import org.junit.Rule;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
 import java.net.HttpURLConnection;
 import java.util.List;
@@ -23,51 +23,51 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Benedict Jin
  * @since 2023/2/5
  */
-@EnableRuleMigrationSupport
+@EnableKubernetesMockClient
 class PodTest {
 
-  @Rule
-  public KubernetesServer server = new KubernetesServer();
+    static KubernetesMockServer server;
+    static KubernetesClient client;
 
-  @Test
-  public void testGetPodList() {
+    @Test
+    public void testGetPodList() {
 
-    Pod pod = new PodBuilder()
-        .withNewMetadata()
-        .withName("yuzhouwan")
-        .endMetadata()
-        .build();
+        Pod pod = new PodBuilder()
+                .withNewMetadata()
+                .withName("yuzhouwan")
+                .endMetadata()
+                .build();
 
-    server.expect()
-        .get()
-        .withPath("/api/v1/pods")
-        .andReturn(HttpURLConnection.HTTP_OK, new PodListBuilder()
-            .withItems(pod)
-            .build())
-        .once();
+        server.expect()
+                .get()
+                .withPath("/api/v1/pods")
+                .andReturn(HttpURLConnection.HTTP_OK, new PodListBuilder()
+                        .withItems(pod)
+                        .build())
+                .once();
 
-    List<Pod> podList = server.getClient()
-        .pods()
-        .inAnyNamespace()
-        .list()
-        .getItems();
-    assertNotNull(podList);
-    assertEquals(1, podList.size());
+        List<Pod> podList = client
+                .pods()
+                .inAnyNamespace()
+                .list()
+                .getItems();
+        assertNotNull(podList);
+        assertEquals(1, podList.size());
 
-    server.expect()
-        .get()
-        .withPath("/api/v1/namespaces/default/pods")
-        .andReturn(HttpURLConnection.HTTP_OK, new PodListBuilder()
-            .withItems()
-            .build())
-        .once();
+        server.expect()
+                .get()
+                .withPath("/api/v1/namespaces/default/pods")
+                .andReturn(HttpURLConnection.HTTP_OK, new PodListBuilder()
+                        .withItems()
+                        .build())
+                .once();
 
-    podList = server.getClient()
-        .pods()
-        .inNamespace("default")
-        .list()
-        .getItems();
+        podList = client
+                .pods()
+                .inNamespace("default")
+                .list()
+                .getItems();
 
-    assertTrue(podList.isEmpty());
-  }
+        assertTrue(podList.isEmpty());
+    }
 }

--- a/yuzhouwan-site/yuzhouwan-site-api/pom.xml
+++ b/yuzhouwan-site/yuzhouwan-site-api/pom.xml
@@ -14,7 +14,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>${hibernate.validator.version}</version>
             <exclusions>

--- a/yuzhouwan-site/yuzhouwan-site-api/pom.xml
+++ b/yuzhouwan-site/yuzhouwan-site-api/pom.xml
@@ -28,6 +28,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Jakarta Bean Validation API (hibernate-validator 8 is jakarta-based) -->
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${jakarta.validation.api.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>

--- a/yuzhouwan-site/yuzhouwan-site-api/src/main/java/com/yuzhouwan/site/api/validation/enums/NotEmpty.java
+++ b/yuzhouwan-site/yuzhouwan-site-api/src/main/java/com/yuzhouwan/site/api/validation/enums/NotEmpty.java
@@ -2,8 +2,8 @@ package com.yuzhouwan.site.api.validation.enums;
 
 import com.yuzhouwan.site.api.validation.model.NotNullValidator;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/yuzhouwan-site/yuzhouwan-site-api/src/main/java/com/yuzhouwan/site/api/validation/model/NotNullValidator.java
+++ b/yuzhouwan-site/yuzhouwan-site-api/src/main/java/com/yuzhouwan/site/api/validation/model/NotNullValidator.java
@@ -2,8 +2,8 @@ package com.yuzhouwan.site.api.validation.model;
 
 import com.yuzhouwan.site.api.validation.enums.NotEmpty;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 /**
  * Copyright @ 2024 yuzhouwan.com

--- a/yuzhouwan-site/yuzhouwan-site-api/src/main/java/com/yuzhouwan/site/api/validation/model/User.java
+++ b/yuzhouwan-site/yuzhouwan-site-api/src/main/java/com/yuzhouwan/site/api/validation/model/User.java
@@ -5,7 +5,7 @@ import com.yuzhouwan.site.api.validation.service.GroupA;
 import com.yuzhouwan.site.api.validation.service.GroupB;
 import org.hibernate.validator.constraints.Length;
 
-import javax.validation.groups.Default;
+import jakarta.validation.groups.Default;
 
 /**
  * Copyright @ 2024 yuzhouwan.com

--- a/yuzhouwan-site/yuzhouwan-site-api/src/main/java/com/yuzhouwan/site/api/validation/model/UserModel.java
+++ b/yuzhouwan-site/yuzhouwan-site-api/src/main/java/com/yuzhouwan/site/api/validation/model/UserModel.java
@@ -6,12 +6,11 @@ import com.wordnik.swagger.annotations.ApiModel;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 import com.yuzhouwan.site.api.validation.service.First;
 import com.yuzhouwan.site.api.validation.service.Second;
-import org.hibernate.validator.constraints.Email;
-
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.Future;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.util.Date;
 
 /**

--- a/yuzhouwan-site/yuzhouwan-site-api/src/main/java/com/yuzhouwan/site/api/validation/service/Group.java
+++ b/yuzhouwan-site/yuzhouwan-site-api/src/main/java/com/yuzhouwan/site/api/validation/service/Group.java
@@ -1,7 +1,7 @@
 package com.yuzhouwan.site.api.validation.service;
 
-import javax.validation.GroupSequence;
-import javax.validation.groups.Default;
+import jakarta.validation.GroupSequence;
+import jakarta.validation.groups.Default;
 
 /**
  * Copyright @ 2024 yuzhouwan.com

--- a/yuzhouwan-site/yuzhouwan-site-service/src/main/java/com/yuzhouwan/site/service/validation/ValidatorController.java
+++ b/yuzhouwan-site/yuzhouwan-site-service/src/main/java/com/yuzhouwan/site/service/validation/ValidatorController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 

--- a/yuzhouwan-site/yuzhouwan-site-web/src/main/java/com/yuzhouwan/site/web/validation/ValidationController.java
+++ b/yuzhouwan-site/yuzhouwan-site-web/src/main/java/com/yuzhouwan/site/web/validation/ValidationController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 /**
  * Copyright @ 2024 yuzhouwan.com


### PR DESCRIPTION
Resolve the API breakage behind four dependabot upgrades that could not merge as-is:

- **snmp4j** 3.8.0 -> 3.12.2 (closes #1013)
- **fabric8** 7.0.1 -> 7.8.0 (closes #1002)
- **hibernate-validator** 5.2.4 -> 8.0.4, javax.validation -> jakarta.validation (closes #1006)
- **disruptor** 3.4.4 -> 4.0.0, WorkHandler -> EventHandler (closes #1044)
