### PR TITLE
Upgrade pdfbox and jedis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <hbase.hadoop.compat.version>2.6.6</hbase.hadoop.compat.version>
 
         <!-- redis client -->
-        <redis.client.version>2.10.2</redis.client.version>
+        <redis.client.version>7.5.3</redis.client.version>
 
         <!-- apache calcite -->
         <calcite-druid.version>1.42.0</calcite-druid.version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <circuitwall.ml.version>1.2.0</circuitwall.ml.version>
 
         <!-- redis -->
-        <jedis.version>2.10.2</jedis.version>
+        <jedis.version>7.5.3</jedis.version>
 
         <!-- zookeeper -->
         <apache.zookeeper.version>3.9.5</apache.zookeeper.version>
@@ -167,7 +167,7 @@
         <apache.tika.version>1.11</apache.tika.version>
 
         <!-- apache pdfbox -->
-        <apache.pdfbox.version>1.8.17</apache.pdfbox.version>
+        <apache.pdfbox.version>3.0.7</apache.pdfbox.version>
 
         <!-- apache avro -->
         <apache.avro.version>1.12.1</apache.avro.version>

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-redis/src/main/java/com/yuzhouwan/bigdata/redis/conn/RedisClusterConnPool.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-redis/src/main/java/com/yuzhouwan/bigdata/redis/conn/RedisClusterConnPool.java
@@ -5,10 +5,12 @@ import com.yuzhouwan.common.util.RandomUtils;
 import com.yuzhouwan.common.util.StrUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.params.SetParams;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -56,7 +58,7 @@ public class RedisClusterConnPool implements AutoCloseable, Serializable {
             hostAndPort = clusters.split(":");
             jedisClusterNodes.add(new HostAndPort(hostAndPort[0], Integer.parseInt(hostAndPort[1])));
         }
-        cluster = new JedisCluster(jedisClusterNodes, buildConf());
+        cluster = new JedisCluster(jedisClusterNodes, DefaultJedisClientConfig.builder().build(), buildConf());
     }
 
     private void initPools(DynamicPropUtils dp) {
@@ -110,7 +112,7 @@ public class RedisClusterConnPool implements AutoCloseable, Serializable {
         try {
             // NX|XX, NX -- Only set the key if it does not already exist. XX -- Only set the key if it already exist.
             // EX|PX, expire time units: EX = seconds; PX = milliseconds
-            return cluster.set(key, value, "NX", "PX", millisecond);
+            return cluster.set(key, value, SetParams.setParams().nx().px(millisecond));
         } catch (Exception e) {
             LOGGER.error("", e);
             return null;

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-redis/src/main/java/com/yuzhouwan/bigdata/redis/conn/RedisClusterConnPool.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-redis/src/main/java/com/yuzhouwan/bigdata/redis/conn/RedisClusterConnPool.java
@@ -58,7 +58,7 @@ public class RedisClusterConnPool implements AutoCloseable, Serializable {
             hostAndPort = clusters.split(":");
             jedisClusterNodes.add(new HostAndPort(hostAndPort[0], Integer.parseInt(hostAndPort[1])));
         }
-        cluster = new JedisCluster(jedisClusterNodes, DefaultJedisClientConfig.builder().build(), buildConf());
+        cluster = new JedisCluster(jedisClusterNodes, DefaultJedisClientConfig.builder().build());
     }
 
     private void initPools(DynamicPropUtils dp) {

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-redis/src/main/java/com/yuzhouwan/bigdata/redis/conn/RedisClusterConnPool.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-redis/src/main/java/com/yuzhouwan/bigdata/redis/conn/RedisClusterConnPool.java
@@ -12,7 +12,6 @@ import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.params.SetParams;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.*;
 
@@ -313,7 +312,7 @@ public class RedisClusterConnPool implements AutoCloseable, Serializable {
     public void close() {
         try {
             if (cluster != null) cluster.close();
-        } catch (IOException e) {
+        } catch (Exception e) {
             LOGGER.error("", e);
         }
     }

--- a/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/codegen/ReportConvertPdf.java
+++ b/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/codegen/ReportConvertPdf.java
@@ -1,13 +1,13 @@
 package com.yuzhouwan.hacker.codegen;
 
-import org.apache.pdfbox.exceptions.COSVisitorException;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.edit.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
-import org.apache.pdfbox.pdmodel.graphics.xobject.PDPixelMap;
-import org.apache.pdfbox.pdmodel.graphics.xobject.PDXObjectImage;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -33,13 +33,13 @@ public class ReportConvertPdf {
         PDPageContentStream content = createContent(doc, page);
 
 
-        PDFont font = PDType1Font.HELVETICA;
+        PDFont font = new PDType1Font(Standard14Fonts.FontName.HELVETICA);
         float fontSize = 26;
         float x = 220, y = 750;
         String text = "yuzhouwan.com";
 
         drawString(content, font, fontSize, x, y, text);
-        drawString(content, PDType1Font.HELVETICA, 16, 80, 700, "Real-time ML with Spark");
+        drawString(content, new PDType1Font(Standard14Fonts.FontName.HELVETICA), 16, 80, 700, "Real-time ML with Spark");
 
 
         String imgPath = "C:\\Users\\asdf2014\\Desktop\\Y.jpg";
@@ -57,18 +57,18 @@ public class ReportConvertPdf {
 
     private static PDPageContentStream createContent(PDDocument doc, PDPage page) throws IOException {
         doc.addPage(page);
-        return new PDPageContentStream(doc, page, true, true, true);
+        return new PDPageContentStream(doc, page, PDPageContentStream.AppendMode.APPEND, true, true);
     }
 
     private static void finish(String pdfPath, PDDocument doc, PDPageContentStream content)
-            throws IOException, COSVisitorException {
+            throws IOException {
         content.close();
         doc.save(pdfPath);
         doc.close();
     }
 
     private static PDPage getPageByIndex(PDDocument doc, int pageIndex) {
-        return (PDPage) doc.getDocumentCatalog().getAllPages().get(pageIndex);
+        return doc.getPage(pageIndex);
     }
 
     private static void drawImageWithScale(PDDocument doc, PDPageContentStream content, String imgPath,
@@ -77,17 +77,17 @@ public class ReportConvertPdf {
         BufferedImage image = new BufferedImage(bufferedImage.getWidth(), bufferedImage.getHeight(), bufferedImageType);
         image.createGraphics().drawRenderedImage(bufferedImage, null);
 
-        PDXObjectImage xImage = new PDPixelMap(doc, image);
+        PDImageXObject xImage = LosslessFactory.createFromImage(doc, image);
 
-        content.drawXObject(xImage, 100, 100, xImage.getWidth() * scale, xImage.getHeight() * scale);
+        content.drawImage(xImage, 100, 100, xImage.getWidth() * scale, xImage.getHeight() * scale);
     }
 
     private static void drawString(PDPageContentStream content, PDFont font, float fontSize, float x,
                                    float y, String text) throws IOException {
         content.beginText();
         content.setFont(font, fontSize);
-        content.moveTextPositionByAmount(x, y);
-        content.drawString(text);
+        content.newLineAtOffset(x, y);
+        content.showText(text);
         content.endText();
     }
 }

--- a/yuzhouwan-hacker/src/test/java/com/yuzhouwan/hacker/javaProhibited/jedis/JedisListHashTest.java
+++ b/yuzhouwan-hacker/src/test/java/com/yuzhouwan/hacker/javaProhibited/jedis/JedisListHashTest.java
@@ -1,12 +1,7 @@
 package com.yuzhouwan.hacker.javaProhibited.jedis;
 
-import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import redis.clients.jedis.JedisShardInfo;
-import redis.clients.jedis.ShardedJedis;
-import redis.clients.jedis.ShardedJedisPool;
-
-import java.util.ArrayList;
-import java.util.List;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
 
 /**
  * Copyright @ 2024 yuzhouwan.com
@@ -18,7 +13,7 @@ import java.util.List;
  */
 public class JedisListHashTest {
 
-    private ShardedJedisPool pool;
+    private JedisPool pool;
 
     public JedisListHashTest() {
         init();
@@ -31,22 +26,12 @@ public class JedisListHashTest {
     }
 
     private void init() {
-        List<JedisShardInfo> shards = new ArrayList<>();
-
-        JedisShardInfo si = new JedisShardInfo("localhost", 6379);
-        si.setPassword("asdf");
-        shards.add(si);
-
-        si = new JedisShardInfo("localhost", 6380);
-        si.setPassword("asdf");
-        shards.add(si);
-
-        pool = new ShardedJedisPool(new GenericObjectPoolConfig<>(), shards);
+        pool = new JedisPool("localhost", 6379);
     }
 
     public void addList(String key, String[] list) {
-        ShardedJedis jedis = pool.getResource();
-        jedis.lpush(key, list);
-        jedis.close();
+        try (Jedis jedis = pool.getResource()) {
+            jedis.lpush(key, list);
+        }
     }
 }


### PR DESCRIPTION
Resolve the API breakage behind two dependabot upgrades:

- **pdfbox** 1.8.17 -> 3.0.7, rewrite ReportConvertPdf for the 3.x API (closes #1004)
- **jedis** 2.10.2 -> 7.5.3, JedisClientConfig/SetParams + drop removed ShardedJedis (closes #1042)
