### PR TITLE
Upgrade kafka to 2.4.1 (new java client API)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <apache.storm.version>2.5.0</apache.storm.version>
 
         <!-- apache kafka-->
-        <apache.kafka.version>1.1.1</apache.kafka.version>
+        <apache.kafka.version>2.4.1</apache.kafka.version>
 
         <!-- lucene -->
         <!-- lucene 10.x requires JDK 21; stay on 9.x while CI builds with JDK 17 -->

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/KafkaConnPoolUtils.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/KafkaConnPoolUtils.java
@@ -2,7 +2,7 @@ package com.yuzhouwan.bigdata.kafka.util;
 
 import com.yuzhouwan.common.util.PropUtils;
 import com.yuzhouwan.common.util.StrUtils;
-import kafka.javaapi.producer.Producer;
+import org.apache.kafka.clients.producer.Producer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/KafkaPartitioner.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/KafkaPartitioner.java
@@ -2,10 +2,12 @@ package com.yuzhouwan.bigdata.kafka.util;
 
 import com.yuzhouwan.common.util.ExceptionUtils;
 import com.yuzhouwan.common.util.StrUtils;
-import kafka.producer.Partitioner;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.Random;
 
 /**
@@ -48,7 +50,16 @@ public class KafkaPartitioner implements Partitioner {
     }
 
     @Override
-    public int partition(Object key, int numPartitions) {
-        return getPartition(key, numPartitions);
+    public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
+        Integer numPartitions = cluster.partitionCountForTopic(topic);
+        return getPartition(key, numPartitions == null ? 0 : numPartitions);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
     }
 }

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/KafkaUtils.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/KafkaUtils.java
@@ -10,12 +10,12 @@ import com.yuzhouwan.bigdata.kafka.util.pc.AvroEventFactory;
 import com.yuzhouwan.bigdata.kafka.util.pc.AvroEventProducer;
 import com.yuzhouwan.bigdata.kafka.util.pc.AvroEventWorkHandler;
 import com.yuzhouwan.common.util.PropUtils;
-import kafka.javaapi.producer.Producer;
-import kafka.producer.ProducerConfig;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,19 +93,14 @@ public final class KafkaUtils {
     static Producer<String, byte[]> createProducer() {
         Properties props = new Properties();
         try {
-//            props.put("zk.connect", p.getProperty("kafka.zk.connect"));   // not need zk in new version
-            props.put("key.serializer.class", p.getProperty("kafka.key.serializer.class"));
-            props.put("serializer.class", p.getProperty("kafka.serializer.class"));
-            props.put("metadata.broker.list", p.getProperty("kafka.metadata.broker.list"));
-            props.put("request.required.acks", p.getProperty("kafka.request.required.acks"));
-            props.put("producer.type", p.getProperty("kafka.async"));
+            props.put("bootstrap.servers", p.getProperty("kafka.bootstrap.servers"));
+            props.put("key.serializer", p.getProperty("kafka.key.serializer"));
+            props.put("value.serializer", p.getProperty("kafka.value.serializer"));
+            props.put("acks", p.getProperty("kafka.acks"));
             props.put("partitioner.class", PARTITIONER_CLASS_NAME);
-
-            props.put("queue.buffering.max.ms", p.getProperty("kafka.queue.buffering.max.ms"));
-            props.put("queue.buffering.max.messages", p.getProperty("kafka.queue.buffering.max.messages"));
-            props.put("queue.enqueue.timeout.ms", p.getProperty("kafka.queue.enqueue.timeout.ms"));
-            // 41,0000,0000 / 24 / 60 / 60 = 47454 / 24 = 1977
-            props.put("batch.num.messages", p.getProperty("kafka.batch.num.messages"));
+            props.put("batch.size", p.getProperty("kafka.batch.size"));
+            props.put("linger.ms", p.getProperty("kafka.linger.ms"));
+            props.put("buffer.memory", p.getProperty("kafka.buffer.memory"));
             props.put("send.buffer.bytes", p.getProperty("kafka.send.buffer.bytes"));
 //            props.put("compression.type", "lz4");
         } catch (Exception e) {
@@ -113,7 +108,7 @@ public final class KafkaUtils {
             throw new RuntimeException(e);
         }
         LOGGER.info("Connect with kafka successfully!");
-        return new Producer<>(new ProducerConfig(props));
+        return new KafkaProducer<>(props);
     }
 
     public static <T> void save2Kafka(final List<T> objs, Class<T> clazz) {

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/clear/ConsumerGroup.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/clear/ConsumerGroup.java
@@ -1,21 +1,17 @@
 package com.yuzhouwan.bigdata.kafka.util.clear;
 
 import com.yuzhouwan.common.util.PropUtils;
-import kafka.consumer.ConsumerConfig;
-import kafka.consumer.KafkaStream;
-import kafka.javaapi.consumer.ConsumerConnector;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
-import static kafka.consumer.Consumer.createJavaConsumerConnector;
 
 /**
  * Copyright @ 2024 yuzhouwan.com
@@ -29,12 +25,11 @@ public class ConsumerGroup {
 
     private static final PropUtils p = PropUtils.getInstance();
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerGroup.class);
-    private final ConsumerConnector consumer;
     private final String topic;
+    private final List<ConsumerWorker> workers = new ArrayList<>();
     private ExecutorService executor;
 
     public ConsumerGroup() {
-        this.consumer = createJavaConsumerConnector(createConsumerConfig());
         this.topic = p.getProperty("kafka.clear.topic");
     }
 
@@ -47,11 +42,10 @@ public class ConsumerGroup {
     }
 
     private void shutdown() {
-        if (consumer != null) consumer.shutdown();
+        for (ConsumerWorker worker : workers) worker.shutdown();
         if (executor != null) executor.shutdown();
         try {
-            assert executor != null;
-            if (!executor.awaitTermination(5000, TimeUnit.MILLISECONDS)) {
+            if (executor != null && !executor.awaitTermination(5000, TimeUnit.MILLISECONDS)) {
                 LOGGER.info("Timed out waiting for consumer threads to shut down, exiting uncleanly");
             }
         } catch (InterruptedException e) {
@@ -60,32 +54,25 @@ public class ConsumerGroup {
     }
 
     private void run(int threadNum) {
-        Map<String, Integer> topicCountMap = new HashMap<>();
-        topicCountMap.put(topic, threadNum);
-        Map<String, List<KafkaStream<byte[], byte[]>>> consumerMap = consumer.createMessageStreams(topicCountMap);
-        List<KafkaStream<byte[], byte[]>> streams = consumerMap.get(topic);
-
         executor = Executors.newFixedThreadPool(threadNum);
-
-        int threadNumber = 0;
-        LOGGER.info("the streams size is {}", streams.size());
-        for (final KafkaStream<byte[], byte[]> stream : streams) {
-            executor.submit(new ConsumerWorker(stream, threadNumber));
-            consumer.commitOffsets();
-            threadNumber++;
+        for (int threadNumber = 0; threadNumber < threadNum; threadNumber++) {
+            ConsumerWorker worker = new ConsumerWorker(createConsumer(), topic, threadNumber);
+            workers.add(worker);
+            executor.submit(worker);
         }
+        LOGGER.info("the consumer worker size is {}", workers.size());
     }
 
-    private ConsumerConfig createConsumerConfig() {
+    private KafkaConsumer<byte[], byte[]> createConsumer() {
         Properties props = new Properties();
-        props.put("zookeeper.connect", p.getProperty("kafka.clear.zookeeper.connect"));
+        props.put("bootstrap.servers", p.getProperty("kafka.clear.bootstrap.servers"));
         props.put("group.id", p.getProperty("kafka.clear.group.id"));
-        props.put("zookeeper.session.timeout.ms", p.getProperty("kafka.clear.zookeeper.session.timeout.ms"));
-        props.put("zookeeper.sync.time.ms", p.getProperty("kafka.clear.zookeeper.sync.time.ms"));
+        props.put("enable.auto.commit", p.getProperty("kafka.clear.enable.auto.commit"));
         props.put("auto.commit.interval.ms", p.getProperty("kafka.clear.auto.commit.interval.ms"));
         props.put("auto.offset.reset", p.getProperty("kafka.clear.auto.offset.reset"));
-        props.put("rebalance.max.retries", p.getProperty("kafka.clear.rebalance.max.retries"));
-        props.put("rebalance.backoff.ms", p.getProperty("kafka.clear.rebalance.backoff.ms"));
-        return new ConsumerConfig(props);
+        props.put("session.timeout.ms", p.getProperty("kafka.clear.session.timeout.ms"));
+        props.put("key.deserializer", ByteArrayDeserializer.class.getName());
+        props.put("value.deserializer", ByteArrayDeserializer.class.getName());
+        return new KafkaConsumer<>(props);
     }
 }

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/clear/ConsumerWorker.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/clear/ConsumerWorker.java
@@ -1,12 +1,15 @@
 package com.yuzhouwan.bigdata.kafka.util.clear;
 
-import kafka.consumer.ConsumerIterator;
-import kafka.consumer.KafkaStream;
-import kafka.message.MessageAndMetadata;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.WakeupException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
 
 /**
  * Copyright @ 2024 yuzhouwan.com
@@ -20,32 +23,46 @@ public class ConsumerWorker implements Runnable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerWorker.class);
 
-    private final KafkaStream<byte[], byte[]> kafkaStream;
+    private final KafkaConsumer<byte[], byte[]> consumer;
+    private final String topic;
     private final int threadNum;
 
-    public ConsumerWorker(KafkaStream<byte[], byte[]> kafkaStream, int threadNum) {
+    public ConsumerWorker(KafkaConsumer<byte[], byte[]> consumer, String topic, int threadNum) {
+        this.consumer = consumer;
+        this.topic = topic;
         this.threadNum = threadNum;
-        this.kafkaStream = kafkaStream;
     }
 
     @Override
     public void run() {
-        ConsumerIterator<byte[], byte[]> iter = kafkaStream.iterator();
-        MessageAndMetadata<byte[], byte[]> msg;
         int total = 0, fail = 0, success = 0;
         long start = System.currentTimeMillis();
-        while (iter.hasNext()) {
-            try {
-                msg = iter.next();
-                LOGGER.info("Thread {}: {}", threadNum, new String(msg.message(), StandardCharsets.UTF_8));
-                LOGGER.info("partition: {}, offset: {}", msg.partition(), msg.offset());
-                success++;
-            } catch (Exception e) {
-                LOGGER.error("", e);
-                fail++;
+        try {
+            consumer.subscribe(Collections.singletonList(topic));
+            while (true) {
+                ConsumerRecords<byte[], byte[]> records = consumer.poll(Duration.ofSeconds(1));
+                for (ConsumerRecord<byte[], byte[]> record : records) {
+                    try {
+                        LOGGER.info("Thread {}: {}", threadNum, new String(record.value(), StandardCharsets.UTF_8));
+                        LOGGER.info("partition: {}, offset: {}", record.partition(), record.offset());
+                        success++;
+                    } catch (Exception e) {
+                        LOGGER.error("", e);
+                        fail++;
+                    }
+                    LOGGER.info("Count [fail/success/total]: [{}/{}/{}], Time: {}s", fail, success, ++total,
+                            (System.currentTimeMillis() - start) / 1000);
+                }
+                consumer.commitSync();
             }
-            LOGGER.info("Count [fail/success/total]: [{}/{}/{}], Time: {}s", fail, success, ++total,
-                    (System.currentTimeMillis() - start) / 1000);
+        } catch (WakeupException e) {
+            LOGGER.info("Consumer worker {} is waking up for shutdown", threadNum);
+        } finally {
+            consumer.close();
         }
+    }
+
+    void shutdown() {
+        consumer.wakeup();
     }
 }

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/pc/AvroEventWorkHandler.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/java/com/yuzhouwan/bigdata/kafka/util/pc/AvroEventWorkHandler.java
@@ -1,8 +1,8 @@
 package com.yuzhouwan.bigdata.kafka.util.pc;
 
 import com.lmax.disruptor.EventHandler;
-import kafka.javaapi.producer.Producer;
-import kafka.producer.KeyedMessage;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
 /**
  * Copyright @ 2024 yuzhouwan.com
@@ -26,6 +26,6 @@ public class AvroEventWorkHandler implements EventHandler<AvroEvent> {
 
     @Override
     public void onEvent(AvroEvent event, long sequence, boolean endOfBatch) {
-        producer.send(new KeyedMessage<>(topic, partition, event.getValue()));
+        producer.send(new ProducerRecord<>(topic, partition, event.getValue()));
     }
 }

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/resources/prop/kafka.clear.properties
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/resources/prop/kafka.clear.properties
@@ -1,12 +1,10 @@
 # consumer
-kafka.clear.zookeeper.connect=yuzhouwan01:2181,yuzhouwan02:2181,yuzhouwan03:2181
+kafka.clear.bootstrap.servers=yuzhouwan01:9092,yuzhouwan02:9092,yuzhouwan03:9092
 kafka.clear.group.id=ops
-kafka.clear.zookeeper.session.timeout.ms=60000
-kafka.clear.zookeeper.sync.time.ms=200
+kafka.clear.enable.auto.commit=false
 kafka.clear.auto.commit.interval.ms=1000
-kafka.clear.auto.offset.reset=largest
-kafka.clear.rebalance.max.retries=5
-kafka.clear.rebalance.backoff.ms=15000
+kafka.clear.auto.offset.reset=latest
+kafka.clear.session.timeout.ms=60000
 # job
 kafka.clear.topic=ops
 kafka.clear.job.thread.num=6

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/resources/prop/kafka.performance.properties
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/resources/prop/kafka.performance.properties
@@ -1,20 +1,14 @@
-## basic ##
-#kafka.key.serializer.class=kafka.serializer.DefaultEncoder
-kafka.serializer.class=kafka.serializer.DefaultEncoder
-kafka.request.required.acks=0
-kafka.async=async
-kafka.queue.buffering.max.ms=5000
-kafka.queue.buffering.max.messages=10000
-kafka.queue.enqueue.timeout.ms=-1
-kafka.batch.num.messages=200
+## producer basic ##
+kafka.key.serializer=org.apache.kafka.common.serialization.StringSerializer
+kafka.value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
+kafka.acks=0
+kafka.batch.size=16384
+kafka.linger.ms=5000
+kafka.buffer.memory=33554432
 kafka.send.buffer.bytes=102400
-## performance ##
-kafka.key.serializer.class=kafka.serializer.StringEncoder
-#kafka.serializer.class=kafka.serializer.StringEncoder
-#kafka.request.required.acks=0
-#kafka.async=async
-#kafka.queue.buffering.max.ms=1000
-#kafka.queue.buffering.max.messages=40000
-#kafka.queue.enqueue.timeout.ms=-1
-#kafka.batch.num.messages=40000
+## producer performance ##
+#kafka.acks=1
+#kafka.batch.size=1048576
+#kafka.linger.ms=1000
+#kafka.buffer.memory=134217728
 #kafka.send.buffer.bytes=8388608

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/resources/prop/kafka.properties
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/main/resources/prop/kafka.properties
@@ -1,4 +1,3 @@
-#kafka.zk.connect=yuzhouwan01:2181,yuzhouwan02:2181,yuzhouwan03:2181
-kafka.metadata.broker.list=yuzhouwan01:9092,yuzhouwan02:9092,yuzhouwan03:9092
+kafka.bootstrap.servers=yuzhouwan01:9092,yuzhouwan02:9092,yuzhouwan03:9092
 kafka.topic=ops
 kafka.conn.2.CONN_IN_POOL=3

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/test/java/com/yuzhouwan/bigdata/kafka/util/KafkaConnPoolUtilsTest.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/test/java/com/yuzhouwan/bigdata/kafka/util/KafkaConnPoolUtilsTest.java
@@ -1,8 +1,8 @@
 package com.yuzhouwan.bigdata.kafka.util;
 
 import com.yuzhouwan.common.util.PropUtils;
-import kafka.javaapi.producer.Producer;
-import kafka.producer.KeyedMessage;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -28,7 +28,7 @@ public class KafkaConnPoolUtilsTest {
         for (int i = 0, max = 1000000000; i < max; i++) {
             System.out.printf("Sending %s/%s ...%n", i, max);
             Thread.sleep(1000);
-            conn.send(new KeyedMessage<>(topic,
+            conn.send(new ProducerRecord<>(topic,
                     ("{\"appId\":1,\"attemptId\":\"2\",\"callId\":\"" + i + "\",\"description\":\"yuzhouwan\"}")
                             .getBytes()));
         }

--- a/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/test/java/com/yuzhouwan/bigdata/kafka/util/KafkaUtilsTest.java
+++ b/yuzhouwan-bigdata/yuzhouwan-bigdata-kafka/src/test/java/com/yuzhouwan/bigdata/kafka/util/KafkaUtilsTest.java
@@ -10,7 +10,7 @@ import com.yuzhouwan.bigdata.kafka.util.pc.AvroEventFactory;
 import com.yuzhouwan.bigdata.kafka.util.pc.AvroEventProducer;
 import com.yuzhouwan.bigdata.kafka.util.pc.AvroEventWorkHandler;
 import com.yuzhouwan.common.util.DecimalUtils;
-import kafka.javaapi.producer.Producer;
+import org.apache.kafka.clients.producer.Producer;
 
 import java.nio.ByteBuffer;
 


### PR DESCRIPTION
Migrate the whole kafka module from the removed Scala API to org.apache.kafka.clients (KafkaProducer/ProducerRecord, new Partitioner, KafkaConsumer poll loop). kafka_2.11 1.1.1 -> 2.4.1. (closes #1019)
