### PR TITLE
Move CI to JDK 21 and upgrade lucene to 10.5.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
         if: matrix.language == 'java'
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.5-openjdk-17 as builder
+FROM maven:3.9-eclipse-temurin-21 as builder
 
 COPY . /src
 WORKDIR /src

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.version>1.0.3</project.version>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
@@ -215,8 +215,7 @@
         <apache.kafka.version>2.4.1</apache.kafka.version>
 
         <!-- lucene -->
-        <!-- lucene 10.x requires JDK 21; stay on 9.x while CI builds with JDK 17 -->
-        <lucene.version>9.12.3</lucene.version>
+        <lucene.version>10.5.0</lucene.version>
 
         <!-- elasticsearch -->
         <elasticsearch.version>7.17.29</elasticsearch.version>


### PR DESCRIPTION
Move the toolchain to JDK 21 so lucene 10.5.0 can be used (its bytecode targets JDK 21). Exploratory: watching whether the scala 2.11 modules (hacker/spark) survive JDK 21. (relates to #1005)
