### PR TITLE
Fix CodeQL findings: unsafe deserialization and weak crypto

### DIFF
--- a/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/security/EncryptClasses.java
+++ b/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/security/EncryptClasses.java
@@ -6,11 +6,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.DESKeySpec;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import java.security.SecureRandom;
 
 import static com.yuzhouwan.hacker.security.SecurityClassLoader.ALGORITHM;
+import static com.yuzhouwan.hacker.security.SecurityClassLoader.IV_LENGTH;
+import static com.yuzhouwan.hacker.security.SecurityClassLoader.TRANSFORMATION;
 
 /**
  * Copyright @ 2024 yuzhouwan.com
@@ -32,21 +34,26 @@ class EncryptClasses {
         SecureRandom sr = new SecureRandom();
         byte[] rawKey = FileUtils.readFile(keyFilename);
         assert rawKey != null;
-        DESKeySpec dks = new DESKeySpec(rawKey);
-        SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(ALGORITHM); // lgtm [java/weak-cryptographic-algorithm]
-        SecretKey key = keyFactory.generateSecret(dks);
-
-        Cipher cipher = Cipher.getInstance(ALGORITHM); // lgtm [java/weak-cryptographic-algorithm]
-        cipher.init(Cipher.ENCRYPT_MODE, key, sr);
+        SecretKey key = new SecretKeySpec(rawKey, ALGORITHM);
 
         String filename;
-        byte[] classData, encryptedClassData;
+        byte[] classData;
         for (int i = 1; i < clazz.length; ++i) {
             filename = clazz[i];
 
             classData = FileUtils.readFile(filename);
             assert classData != null;
-            encryptedClassData = cipher.doFinal(classData);
+
+            // a fresh random IV per file; store it as [16-byte IV][ciphertext]
+            byte[] iv = new byte[IV_LENGTH];
+            sr.nextBytes(iv);
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(iv));
+            byte[] cipherText = cipher.doFinal(classData);
+
+            byte[] encryptedClassData = new byte[iv.length + cipherText.length];
+            System.arraycopy(iv, 0, encryptedClassData, 0, iv.length);
+            System.arraycopy(cipherText, 0, encryptedClassData, iv.length, cipherText.length);
             FileUtils.writeFile(filename, encryptedClassData);
 
             LOGGER.debug("Encrypted {}", filename);

--- a/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/security/GenerateKey.java
+++ b/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/security/GenerateKey.java
@@ -20,11 +20,9 @@ class GenerateKey {
      * @param keyFileName key.data
      */
     static void generate(String keyFileName) throws Exception {
-        SecureRandom sr = new SecureRandom();
-        KeyGenerator kg = KeyGenerator.getInstance(SecurityClassLoader.ALGORITHM); // lgtm [java/weak-cryptographic-algorithm]
-        kg.init(sr);
+        KeyGenerator kg = KeyGenerator.getInstance(SecurityClassLoader.ALGORITHM);
+        kg.init(128, new SecureRandom());
         SecretKey key = kg.generateKey();
         FileUtils.writeFile(keyFileName, key.getEncoded());
     }
 }
-

--- a/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/security/SafeApp.java
+++ b/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/security/SafeApp.java
@@ -5,8 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.crypto.SecretKey;
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.DESKeySpec;
+import javax.crypto.spec.SecretKeySpec;
 import java.lang.reflect.Method;
 
 /**
@@ -40,9 +39,7 @@ public class SafeApp {
 
         byte[] rawKey = FileUtils.readFile(KEY_FILENAME);
         assert rawKey != null;
-        DESKeySpec dks = new DESKeySpec(rawKey);
-        SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(SecurityClassLoader.ALGORITHM);  // lgtm [java/weak-cryptographic-algorithm]
-        SecretKey key = keyFactory.generateSecret(dks);
+        SecretKey key = new SecretKeySpec(rawKey, SecurityClassLoader.ALGORITHM);
 
         SecurityClassLoader dr = new SecurityClassLoader(key);
 

--- a/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/security/SecurityClassLoader.java
+++ b/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/security/SecurityClassLoader.java
@@ -6,10 +6,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.security.SecureRandom;
+import java.util.Arrays;
 
 /**
  * Copyright @ 2024 yuzhouwan.com
@@ -23,16 +24,17 @@ class SecurityClassLoader extends ClassLoader {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SecurityClassLoader.class);
 
-    static final String ALGORITHM = "DES";
+    static final String ALGORITHM = "AES";
+    static final String TRANSFORMATION = "AES/CBC/PKCS5Padding";
+    static final int IV_LENGTH = 16;
     private static final String CLASSES_PATH = "F:/如何成为 Java 高手/笔记/Soft Engineering/Git/[code]/"
         + "yuzhouwan/yuzhouwan-hacker/target/classes/com/yuzhouwan/hacker/security/";
 
-    private final Cipher cipher;
+    private final SecretKey key;
 
-    SecurityClassLoader(SecretKey key) throws GeneralSecurityException {
-        LOGGER.error("[SecurityClassLoader: creating cipher]");
-        cipher = Cipher.getInstance(ALGORITHM);  // lgtm [java/weak-cryptographic-algorithm]
-        cipher.init(Cipher.DECRYPT_MODE, key, new SecureRandom());
+    SecurityClassLoader(SecretKey key) {
+        LOGGER.error("[SecurityClassLoader: holding key]");
+        this.key = key;
     }
 
     @Override
@@ -48,7 +50,12 @@ class SecurityClassLoader extends ClassLoader {
                 } else classData = FileUtils.readFile(name);
 
                 if (classData != null) {
-                    byte[] decryptedClassData = cipher.doFinal(classData);
+                    // the file layout is [16-byte random IV][AES/CBC ciphertext]
+                    byte[] iv = Arrays.copyOfRange(classData, 0, IV_LENGTH);
+                    byte[] cipherText = Arrays.copyOfRange(classData, IV_LENGTH, classData.length);
+                    Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+                    cipher.init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(iv));
+                    byte[] decryptedClassData = cipher.doFinal(cipherText);
                     clazz = defineClass(name, decryptedClassData, 0, decryptedClassData.length);
                     LOGGER.error("[SecurityClassLoader: decrypting class " + name + "]");
                 }
@@ -59,9 +66,7 @@ class SecurityClassLoader extends ClassLoader {
             if (resolve && clazz != null) resolveClass(clazz);
             return clazz;
         } catch (IOException | GeneralSecurityException e) {
-            // if java.lang.ClassNotFoundException:
-            // Input length must be multiple of 8 when decrypting with padded cipher,
-            // then mvn clean (DO NOT mvn install!!)
+            // if java.lang.ClassNotFoundException, then mvn clean (DO NOT mvn install!!)
             // & run com.yuzhouwan.hacker.security.GenerateKeyTest.generate to generate key
             // & run com.yuzhouwan.hacker.security.EncryptClassesTest.encrypt() to encrypt unsafe class files
             throw new ClassNotFoundException(e.getMessage());

--- a/yuzhouwan-site/yuzhouwan-site-service/src/main/java/com/yuzhouwan/site/service/rpc/connection/Client.java
+++ b/yuzhouwan-site/yuzhouwan-site-service/src/main/java/com/yuzhouwan/site/service/rpc/connection/Client.java
@@ -3,6 +3,7 @@ package com.yuzhouwan.site.service.rpc.connection;
 import com.yuzhouwan.site.api.rpc.model.Call;
 
 import java.io.IOException;
+import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.Socket;
@@ -16,6 +17,10 @@ import java.net.Socket;
  * @since 2016/9/1
  */
 public class Client {
+
+    // allow only the RPC model and JDK types, reject everything else (blocks deserialization gadget chains)
+    private static final ObjectInputFilter CALL_FILTER =
+            ObjectInputFilter.Config.createFilter("com.yuzhouwan.**;java.**;!*");
 
     private Socket socket;
     private ObjectOutputStream oos;
@@ -39,7 +44,8 @@ public class Client {
         oos.flush();
         //waiting server to send result...
         ois = new ObjectInputStream(socket.getInputStream());
-        Call resultCall = (Call) ois.readObject();  // lgtm [java/unsafe-deserialization]
+        ois.setObjectInputFilter(CALL_FILTER);
+        Call resultCall = (Call) ois.readObject();
         call.setResult(resultCall.getResult());
     }
 

--- a/yuzhouwan-site/yuzhouwan-site-service/src/main/java/com/yuzhouwan/site/service/rpc/connection/Listener.java
+++ b/yuzhouwan-site/yuzhouwan-site-service/src/main/java/com/yuzhouwan/site/service/rpc/connection/Listener.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.ServerSocket;
@@ -22,6 +23,10 @@ import java.net.Socket;
 public class Listener implements Runnable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Listener.class);
+
+    // allow only the RPC model and JDK types, reject everything else (blocks deserialization gadget chains)
+    private static final ObjectInputFilter CALL_FILTER =
+            ObjectInputFilter.Config.createFilter("com.yuzhouwan.**;java.**;!*");
 
     private final Server server;
 
@@ -45,7 +50,8 @@ public class Listener implements Runnable {
                 Socket clientSocket = serversocket.accept();
                 // 获取客户端的请求
                 ois = new ObjectInputStream(clientSocket.getInputStream());
-                Call call = (Call) ois.readObject();  // lgtm [java/unsafe-deserialization]
+                ois.setObjectInputFilter(CALL_FILTER);
+                Call call = (Call) ois.readObject();
                 // 服务器处理
                 server.call(call);
 


### PR DESCRIPTION
Address the CodeQL code-scanning alerts:

- **critical** `java/unsafe-deserialization` (RPC Client/Listener) — install an `ObjectInputFilter` allow-list before `readObject`
- **high** `java/weak-cryptographic-algorithm` (hacker/security demo) — migrate the class-file cipher from DES to AES/CBC with a random IV

The remaining findings (the intentional trust-all `HttpUtils.coverCA` and the ReDoS/URL findings in the vendored `marked.js`) are dismissed on the code-scanning dashboard with reasons.
