### PR TITLE
Use authenticated AES-GCM for the class-file cipher demo

### DIFF
--- a/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/security/EncryptClasses.java
+++ b/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/security/EncryptClasses.java
@@ -6,11 +6,12 @@ import org.slf4j.LoggerFactory;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.SecureRandom;
 
 import static com.yuzhouwan.hacker.security.SecurityClassLoader.ALGORITHM;
+import static com.yuzhouwan.hacker.security.SecurityClassLoader.GCM_TAG_BITS;
 import static com.yuzhouwan.hacker.security.SecurityClassLoader.IV_LENGTH;
 import static com.yuzhouwan.hacker.security.SecurityClassLoader.TRANSFORMATION;
 
@@ -44,11 +45,11 @@ class EncryptClasses {
             classData = FileUtils.readFile(filename);
             assert classData != null;
 
-            // a fresh random IV per file; store it as [16-byte IV][ciphertext]
+            // a fresh random nonce per file; store it as [12-byte nonce][ciphertext]
             byte[] iv = new byte[IV_LENGTH];
             sr.nextBytes(iv);
             Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-            cipher.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(iv));
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_BITS, iv));
             byte[] cipherText = cipher.doFinal(classData);
 
             byte[] encryptedClassData = new byte[iv.length + cipherText.length];

--- a/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/security/SecurityClassLoader.java
+++ b/yuzhouwan-hacker/src/main/java/com/yuzhouwan/hacker/security/SecurityClassLoader.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -25,8 +25,9 @@ class SecurityClassLoader extends ClassLoader {
     private static final Logger LOGGER = LoggerFactory.getLogger(SecurityClassLoader.class);
 
     static final String ALGORITHM = "AES";
-    static final String TRANSFORMATION = "AES/CBC/PKCS5Padding";
-    static final int IV_LENGTH = 16;
+    static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    static final int GCM_TAG_BITS = 128;
+    static final int IV_LENGTH = 12;
     private static final String CLASSES_PATH = "F:/如何成为 Java 高手/笔记/Soft Engineering/Git/[code]/"
         + "yuzhouwan/yuzhouwan-hacker/target/classes/com/yuzhouwan/hacker/security/";
 
@@ -50,11 +51,11 @@ class SecurityClassLoader extends ClassLoader {
                 } else classData = FileUtils.readFile(name);
 
                 if (classData != null) {
-                    // the file layout is [16-byte random IV][AES/CBC ciphertext]
+                    // the file layout is [12-byte random nonce][AES-GCM ciphertext]
                     byte[] iv = Arrays.copyOfRange(classData, 0, IV_LENGTH);
                     byte[] cipherText = Arrays.copyOfRange(classData, IV_LENGTH, classData.length);
                     Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-                    cipher.init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(iv));
+                    cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_BITS, iv));
                     byte[] decryptedClassData = cipher.doFinal(cipherText);
                     clazz = defineClass(name, decryptedClassData, 0, decryptedClassData.length);
                     LOGGER.error("[SecurityClassLoader: decrypting class " + name + "]");


### PR DESCRIPTION
Follow-up to #1051: CodeQL flags AES/CBC as an unauthenticated (weak) mode, so switch the class-file cipher demo to authenticated AES/GCM/NoPadding with a random 96-bit nonce.
